### PR TITLE
Fix path issue

### DIFF
--- a/bin/genem
+++ b/bin/genem
@@ -16,7 +16,6 @@ var genem = require('../')
   , mkdirp = require('mkdirp')
   , program = require('commander')
   , fs = require('fs')
-  , path = program._args.shift() || '.'
   , os = require('os')
   , eol = 'win32' == os.platform() ? '\r\n' : '\n'
   , inflection = require('inflection')
@@ -26,28 +25,28 @@ program
   .command('init <app>')
   .description('initialize app with name <app>')
   .action(function(app){
-    createApplication(path, app);
+    createApplication(app, app);
   });
 
 program
   .command('model <model>')
   .description('creates a mongoose model of name <model>')
   .action(function(model){
-    createModel(path, model);
+    createModel('.', model);
   });
 
 program
   .command('controller <controller>')
   .description('creates a controller of name <controller>')
   .action(function(controller){
-    createController(path, controller);
+    createController('.', controller);
   });
 
 program
   .command('view <view>')
   .description('creates a view of name <view>')
   .action(function(view){
-    createView(path, view);
+    createView('.', view);
   });
 
 program


### PR DESCRIPTION
Hi madhums,

I should probably have made an issue first, anyway...

I tried to use node-genem and for me it would always try to generate the code in the current dir.

It seems like the path is always empty, because ._args is always empty, this means the path will always be '.'

For the generation of the models and views etc. I hardcoded the path to '.', effectively that's how it always worked accidently.

For the init option I took the app name as path, for this is what one would expect.

If you don't know what I'm talking about or have a better sollution yourself, feel free to deny this request :-)

Greetings,
Rob Halff
